### PR TITLE
feat: added option to wait on output-schema before finish

### DIFF
--- a/packages/output-schema/.actor/actor.json
+++ b/packages/output-schema/.actor/actor.json
@@ -7,6 +7,7 @@
     "version": "0.0",
     "buildTag": "latest",
     "dockerfile": "../Dockerfile",
+    "input": "./input_schema.json",
     "output": "./output_schema.json",
     "webServerSchema": "./web_server_schema.json",
     "storages": {

--- a/packages/output-schema/.actor/input_schema.json
+++ b/packages/output-schema/.actor/input_schema.json
@@ -1,0 +1,26 @@
+{
+    "title": "Output Schema Actor input",
+    "type": "object",
+    "schemaVersion": 1,
+    "properties": {
+        "liveViewDelaySecs": {
+            "title": "Live view start delay (seconds)",
+            "type": "integer",
+            "description": "How many seconds to wait after the run starts before the live view becomes available. The Actor still produces its output (key-value files and datasets) immediately — only the live view is delayed. Set to 0 to start the live view right away.",
+            "editor": "number",
+            "unit": "seconds",
+            "default": 0,
+            "minimum": 0
+        },
+        "maxRunTimeSecs": {
+            "title": "Auto-stop timeout (seconds)",
+            "type": "integer",
+            "description": "Maximum total run time in seconds, measured from the start of the run (the live view delay counts towards it). When the limit is reached, the Actor stops itself. Set to 0 (default) to run indefinitely until you press Stop in the live view or abort the run.",
+            "editor": "number",
+            "unit": "seconds",
+            "default": 0,
+            "minimum": 0
+        }
+    },
+    "required": []
+}

--- a/packages/output-schema/README.md
+++ b/packages/output-schema/README.md
@@ -13,6 +13,17 @@ Start a new [web scraping](https://apify.com/web-scraping) project quickly and e
 
 Insert your own code between `await Actor.init()` and `await Actor.exit()`. If you would like to use the [Crawlee](https://crawlee.dev/) library simply uncomment its import `import { CheerioCrawler } from '@crawlee/cheerio';`.
 
+## Input
+
+The Actor produces its output (key-value files and datasets) immediately, then keeps running so you can open the live view. Two optional fields control its lifecycle:
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `liveViewDelaySecs` | integer (seconds) | `0` | How long to wait after the run starts before the live view becomes available. `0` starts it right away. |
+| `maxRunTimeSecs` | integer (seconds) | `0` | Total run-time cap, measured from run start (the live-view delay counts towards it). The Actor stops itself once reached. `0` runs indefinitely until you press **Stop** in the live view or abort the run. |
+
+Both default to `0`, which preserves the original behavior: the live view starts immediately and the run lives on until you stop it manually.
+
 ## Resources
 
 - [TypeScript vs. JavaScript: which to use for web scraping?](https://blog.apify.com/typescript-vs-javascript-crawler/)

--- a/packages/output-schema/src/main.ts
+++ b/packages/output-schema/src/main.ts
@@ -1,18 +1,59 @@
+import { setTimeout as delay } from "node:timers/promises";
+
 import { Actor, log } from "apify";
 
 import { startLiveView } from "./live_view.js";
 import { pushDatasets, writeKeyValueFiles } from "./writes.js";
 
+interface Input {
+    /** Seconds to wait after run start before the live view becomes available (0 = no delay). */
+    liveViewDelaySecs?: number;
+    /** Total run-time cap in seconds, measured from run start (0 = run indefinitely). */
+    maxRunTimeSecs?: number;
+}
+
 await Actor.init();
 
-startLiveView();
+const input = (await Actor.getInput<Input>()) ?? {};
+const liveViewDelaySecs = Math.max(0, Math.trunc(input.liveViewDelaySecs ?? 0));
+const maxRunTimeSecs = Math.max(0, Math.trunc(input.maxRunTimeSecs ?? 0));
 
+// Schedule the automatic stop from run start. When 0, the Actor keeps the historical
+// behavior of running forever until the user hits Stop in the live view or aborts the run.
+if (maxRunTimeSecs > 0) {
+    if (liveViewDelaySecs >= maxRunTimeSecs) {
+        log.warning(
+            `Live view delay (${liveViewDelaySecs}s) is greater than or equal to the auto-stop timeout ` +
+                `(${maxRunTimeSecs}s) — the Actor will stop before the live view becomes available.`,
+        );
+    }
+    log.info(`Actor will stop automatically ${maxRunTimeSecs}s after start.`);
+    // Not unref()'d on purpose: this timer is what keeps the process alive until the limit is hit.
+    setTimeout(() => {
+        log.info(`Reached the ${maxRunTimeSecs}s run-time limit — stopping.`);
+        void Actor.exit();
+    }, maxRunTimeSecs * 1000);
+}
+
+// Produce the output first so it is ready regardless of any live-view delay.
 const fileCount = await writeKeyValueFiles();
 log.info(`Stored ${fileCount} files in the default key-value store.`);
 
 await pushDatasets();
 
-log.info("Writes complete. Live view is still up — abort the run to exit.");
+// Optionally hold off on exposing the live view.
+if (liveViewDelaySecs > 0) {
+    log.info(`Waiting ${liveViewDelaySecs}s before starting the live view…`);
+    await delay(liveViewDelaySecs * 1000);
+}
+
+startLiveView();
+
+log.info(
+    maxRunTimeSecs > 0
+        ? `Writes complete. Live view is up — it will close after the ${maxRunTimeSecs}s limit, or when you Stop/abort the run.`
+        : "Writes complete. Live view is still up — abort the run or press Stop to exit.",
+);
 
 // Keep the actor running to allow viewing the live view.
 await new Promise(() => {});


### PR DESCRIPTION
This PR adds an option to provide time before live view starts and optional timeout before Actor finishes to the output-schema Actor.