### PR TITLE
feat: mcp-list-tools actor

### DIFF
--- a/packages/mcp-list-tools/.actor/actor.json
+++ b/packages/mcp-list-tools/.actor/actor.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "https://apify.com/schemas/v1/actor.ide.json",
+    "actorSpecification": 1,
+    "name": "mcp-list-tools",
+    "title": "MCP List Tools",
+    "description": "Lists all tools available on an MCP connector and saves them to the key-value store",
+    "version": "0.0",
+    "buildTag": "latest",
+    "meta": {
+        "templateId": "ts-empty",
+        "generatedBy": "Claude Code with Claude Sonnet 4.6"
+    },
+    "dockerfile": "../Dockerfile",
+    "input": "./input_schema.json",
+    "output": {
+        "actorOutputSchemaVersion": 1,
+        "title": "MCP tools list",
+        "properties": {
+            "tools": {
+                "type": "string",
+                "title": "Tools",
+                "template": "{{links.apiDefaultKeyValueStoreUrl}}/records/OUTPUT"
+            }
+        }
+    },
+    "storages": {
+        "keyValueStore": {
+            "actorKeyValueStoreSchemaVersion": 1,
+            "title": "MCP List Tools output",
+            "collections": {
+                "output": {
+                    "title": "Output",
+                    "description": "JSON record containing the list of tools available on the MCP connector",
+                    "key": "OUTPUT",
+                    "contentTypes": ["application/json"]
+                }
+            }
+        }
+    }
+}

--- a/packages/mcp-list-tools/.actor/input_schema.json
+++ b/packages/mcp-list-tools/.actor/input_schema.json
@@ -1,0 +1,15 @@
+{
+    "title": "MCP List Tools",
+    "description": "Lists all tools available on an MCP connector.",
+    "type": "object",
+    "schemaVersion": 1,
+    "properties": {
+        "mcpConnector": {
+            "title": "MCP Connector",
+            "description": "Connector to the MCP server whose tools you want to list",
+            "type": "string",
+            "resourceType": "mcpConnector"
+        }
+    },
+    "required": ["mcpConnector"]
+}

--- a/packages/mcp-list-tools/.actor/input_schema.json
+++ b/packages/mcp-list-tools/.actor/input_schema.json
@@ -8,7 +8,10 @@
             "title": "MCP Connector",
             "description": "Connector to the MCP server whose tools you want to list",
             "type": "string",
-            "resourceType": "mcpConnector"
+            "resourceType": "mcpConnector",
+            "mcpServers": [
+                { "url": "*" }
+            ]
         }
     },
     "required": ["mcpConnector"]

--- a/packages/mcp-list-tools/.dockerignore
+++ b/packages/mcp-list-tools/.dockerignore
@@ -1,0 +1,18 @@
+# configurations
+.idea
+.vscode
+.zed
+
+# crawlee and apify storage folders
+apify_storage
+crawlee_storage
+storage
+
+# installed files
+node_modules
+
+# git folder
+.git
+
+# dist folder
+dist

--- a/packages/mcp-list-tools/Dockerfile
+++ b/packages/mcp-list-tools/Dockerfile
@@ -1,0 +1,11 @@
+FROM apify/actor-node:24
+
+# Next, copy the source files using the user set
+# in the base image.
+COPY --chown=myuser:myuser . ./
+
+# Install all dependencies. Don't audit to speed up the installation.
+RUN npm install --include=dev --audit=false
+
+# Run the image.
+CMD ["npm", "run", "start"]

--- a/packages/mcp-list-tools/README.md
+++ b/packages/mcp-list-tools/README.md
@@ -1,0 +1,30 @@
+# MCP List Tools
+
+Lists all tools available on an MCP connector and saves them as a JSON record to the key-value store.
+
+## Input
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `mcpConnector` | MCP Connector | The MCP connector whose tools you want to list. Works with any MCP server. |
+
+## Output
+
+A single JSON record saved to the key-value store under the key `OUTPUT`:
+
+```json
+{
+  "connectorId": "abc123",
+  "toolCount": 3,
+  "tools": [
+    {
+      "name": "call-actor",
+      "title": "Call Actor",
+      "description": "Runs an Apify Actor and returns its output.",
+      "inputSchema": { ... }
+    }
+  ]
+}
+```
+
+The record is accessible via the **Tools** link in the Actor run output.

--- a/packages/mcp-list-tools/package.json
+++ b/packages/mcp-list-tools/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "mcp-list-tools",
+    "version": "0.0.1",
+    "type": "module",
+    "description": "Lists all tools available on an MCP connector.",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "dependencies": {
+        "apify": "^3.7.0",
+        "@modelcontextprotocol/sdk": "^1.28.0",
+        "zod": "^4.3.6",
+        "tsx": "^4.20.3",
+        "@apify/tsconfig": "^0.1.1",
+        "@types/node": "^24.0.0",
+        "globals": "^17.0.0"
+    },
+    "scripts": {
+        "start": "tsx src/main.ts"
+    },
+    "author": "Apify",
+    "license": "ISC"
+}

--- a/packages/mcp-list-tools/src/main.ts
+++ b/packages/mcp-list-tools/src/main.ts
@@ -33,7 +33,7 @@ const result = {
     tools,
 };
 
-await Actor.setValue('OUTPUT', result, { contentType: 'application/json' });
+await Actor.setValue('OUTPUT', result);
 
 log.info(`Found ${tools.length} tools on connector "${mcpConnector}"`);
 

--- a/packages/mcp-list-tools/src/main.ts
+++ b/packages/mcp-list-tools/src/main.ts
@@ -1,0 +1,41 @@
+import { Actor, log } from 'apify';
+
+import { createMcpClient } from './utils.js';
+
+await Actor.init();
+
+const mcpProxyUrl = process.env.APIFY_MCP_PROXY_URL;
+if (!mcpProxyUrl) throw new Error('Missing APIFY_MCP_PROXY_URL env variable');
+
+const token = process.env.APIFY_TOKEN!;
+
+type Input = {
+    mcpConnector: string;
+};
+
+const { mcpConnector } = await Actor.getInputOrThrow<Input>();
+
+log.info('Connecting to MCP server...', { mcpConnector });
+const client = await createMcpClient(mcpProxyUrl, mcpConnector, token);
+
+const { tools: rawTools } = await client.listTools();
+
+const tools = rawTools.map((tool) => ({
+    name: tool.name,
+    title: tool.annotations?.title ?? undefined,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+}));
+
+const result = {
+    connectorId: mcpConnector,
+    toolCount: tools.length,
+    tools,
+};
+
+await Actor.setValue('OUTPUT', result, { contentType: 'application/json' });
+
+log.info(`Found ${tools.length} tools on connector "${mcpConnector}"`);
+
+await client.close();
+await Actor.exit();

--- a/packages/mcp-list-tools/src/utils.ts
+++ b/packages/mcp-list-tools/src/utils.ts
@@ -1,0 +1,20 @@
+import { log } from 'apify';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+export const createMcpClient = async (mcpProxyUrl: string, connectorId: string, token: string) => {
+    const url = `${mcpProxyUrl}/${connectorId}`;
+    log.info('Connecting to MCP endpoint', { url });
+
+    const transport = new StreamableHTTPClientTransport(new URL(url), {
+        requestInit: {
+            headers: { Authorization: `Bearer ${token}` },
+        },
+    });
+
+    const client = new Client({ name: 'apify-mcp-list-tools', version: '1.0.0' });
+    await client.connect(transport);
+
+    return client;
+};

--- a/packages/mcp-list-tools/tsconfig.json
+++ b/packages/mcp-list-tools/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "@apify/tsconfig",
+    "compilerOptions": {
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "target": "ES2022",
+        "outDir": "dist",
+        "noUnusedLocals": false,
+        "skipLibCheck": true,
+        "lib": ["DOM"]
+    },
+    "include": ["./src/**/*"]
+}


### PR DESCRIPTION
I want to use this Actor for integration tests for MCP.


It produces the list of tools available at specific mcp connector to the key-value store.

Vibe-coded with our agentic skills, worked pretty good.


Example run: https://console-securitybyobscurity.apify.com/actors/runs/3tEhzxm7xYLgxlzIK#output