### PR TITLE
chore: add readme to Actors

### DIFF
--- a/packages/benchmark-disk/README.md
+++ b/packages/benchmark-disk/README.md
@@ -1,0 +1,3 @@
+# benchmark-disk
+
+Disk I/O benchmark Actor (single-file variant of `benchmark`). Loops forever writing 500 files of 25 MB each (pseudo-random bytes) in parallel, logging `writing` per iteration. Used to stress and measure container disk throughput.

--- a/packages/benchmark/README.md
+++ b/packages/benchmark/README.md
@@ -1,0 +1,3 @@
+# benchmark
+
+Disk I/O benchmark Actor. Loops forever writing 500 files of 25 MB each (pseudo-random bytes) in parallel to the working directory, logging `writing` on every iteration. Used to stress and measure container disk throughput.

--- a/packages/concurrency-test/README.md
+++ b/packages/concurrency-test/README.md
@@ -1,0 +1,3 @@
+# concurrency-test
+
+Concurrency test Actor. Reads `actorNo` from input and pushes 100 timestamped items into a shared named dataset (`concurrency-testing-dataset`). Run multiple instances at once to verify concurrent writes to the same dataset.

--- a/packages/dataset-test/README.md
+++ b/packages/dataset-test/README.md
@@ -1,0 +1,3 @@
+# dataset-test
+
+Dataset test Actor. Pushes 5 wide items (each with 4096 columns) to the default dataset, sleeping 100 ms between writes. Used to exercise large/wide dataset records.

--- a/packages/fast-and-furious/README.md
+++ b/packages/fast-and-furious/README.md
@@ -1,0 +1,3 @@
+# fast-and-furious
+
+Minimal shell Actor. Runs `main.sh`, which just echoes a line and exits — the fastest possible successful run. Used to test container startup and finish overhead.

--- a/packages/filler-aggressive/README.md
+++ b/packages/filler-aggressive/README.md
@@ -1,0 +1,3 @@
+# filler-aggressive
+
+Dataset write-throughput benchmark. Pushes 3000-item batches to the default dataset in three modes — bulk `pushData`, one-by-one, and parallel — timing each. Used to compare dataset write performance under load.

--- a/packages/filler-poluter/README.md
+++ b/packages/filler-poluter/README.md
@@ -1,0 +1,3 @@
+# filler-poluter
+
+Storage-pollution Actor. Creates 15 named key-value stores and writes 3000 keys to each. Used to populate accounts with many stores/records for load and cleanup testing.

--- a/packages/filler/README.md
+++ b/packages/filler/README.md
@@ -1,0 +1,3 @@
+# filler
+
+Storage sampler Actor. Populates default and named request queues, datasets, and key-value stores with 10 sample records each. Used to seed all storage types with test data.

--- a/packages/infinite/README.md
+++ b/packages/infinite/README.md
@@ -1,0 +1,3 @@
+# infinite
+
+Never-ending Actor. Logs an incrementing counter and a random number every 100 ms, forever. Used to test long-running runs, timeouts, and log streaming.

--- a/packages/input-schema/README.md
+++ b/packages/input-schema/README.md
@@ -1,0 +1,3 @@
+# input-schema
+
+Input-schema inspector Actor. `INPUT_SCHEMA.json` exercises every field type, editor, and constraint (enum, string, array, object, integer, boolean, proxy, patterns, min/max, default/prefill/example). The Actor simply logs the parsed `INPUT`. Used to test input-schema rendering and validation.

--- a/packages/kitchensink/README.md
+++ b/packages/kitchensink/README.md
@@ -1,0 +1,3 @@
+# kitchensink
+
+Environment dump Actor. Prints the full `process.env` to the log. Used to inspect which environment variables the platform injects into a run.

--- a/packages/log-color-test/README.md
+++ b/packages/log-color-test/README.md
@@ -1,0 +1,3 @@
+# log-color-test
+
+ANSI log-rendering test Actor. Emits colored log lines plus ASCII-art (the Apify logo and a portrait) using ANSI escape codes. Used to verify color handling in the log viewer.

--- a/packages/log-test/README.md
+++ b/packages/log-test/README.md
@@ -1,0 +1,3 @@
+# log-test
+
+Log-rate test Actor. Reads `logDelaySeconds` from input and logs an incrementing counter at that interval, forever (exits with error if the input is missing). Used to test log throughput and streaming.

--- a/packages/multiple-datasets-alpine/README.md
+++ b/packages/multiple-datasets-alpine/README.md
@@ -1,0 +1,3 @@
+# multiple-datasets-alpine
+
+Minimal Alpine shell Actor. Prints the `ACTOR_STORAGES_JSON` environment variable (pretty-printed with `jq`). Used to inspect the storages configuration passed to a run.

--- a/packages/queue-test/README.md
+++ b/packages/queue-test/README.md
@@ -1,0 +1,3 @@
+# queue-test
+
+Request queue test Actor. In a long loop, adds a request, fetches the next one, and marks it handled — one every 2 seconds. Used to exercise request queue add/fetch/handle operations over time.

--- a/packages/store-test/README.md
+++ b/packages/store-test/README.md
@@ -1,0 +1,3 @@
+# store-test
+
+Key-value store test Actor. In a long loop, writes, reads, then clears a record in a named KV store every 2 seconds. Used to exercise KV store set/get/delete operations over time.

--- a/packages/timeout-test-2/README.md
+++ b/packages/timeout-test-2/README.md
@@ -1,0 +1,3 @@
+# timeout-test-2
+
+Timeout test Actor. Sleeps for 30 minutes then exits. Used to verify long-running behavior against configured run timeouts.

--- a/packages/timeout-test/README.md
+++ b/packages/timeout-test/README.md
@@ -1,0 +1,3 @@
+# timeout-test
+
+Timeout test Actor. Hangs indefinitely on an unresolved promise, doing nothing. Used to verify the platform enforces the run timeout limit.

--- a/packages/webserver/README.md
+++ b/packages/webserver/README.md
@@ -1,0 +1,3 @@
+# webserver
+
+Standby/web-server test Actor. Runs an Express server on the container port that responds to `GET /` with a JSON array of 0–999. Used to test the platform's container HTTP proxying.

--- a/packages/websocket-server/README.md
+++ b/packages/websocket-server/README.md
@@ -1,0 +1,3 @@
+# websocket-server
+
+WebSocket test Actor. Runs a `ws` server on the container port that greets each connection, echoes messages back, and closes when it receives a message containing `end`. Used to test WebSocket proxying to containers.


### PR DESCRIPTION
implements https://github.com/apify/apify-core/issues/29204

Before: Not all Actors had a README
Now: All Actors have README